### PR TITLE
Implement basic finance model example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
-# IA_Finance
+# IA Finance
+
+This repository contains a simple example of a machine learning model for financial time series.
+
+The script `finance_model.py` trains a linear regression model to predict the next closing price of a
+stock using lagged values. The code attempts to download real data using the `yfinance` package, but
+falls back to generating synthetic data if the download fails (for example in offline environments).
+
+## Requirements
+
+- Python 3.10+
+- `numpy`
+- `pandas`
+- `scikit-learn`
+- `yfinance` (optional, for fetching live data)
+
+All dependencies can be installed with `pip install -r requirements.txt`. A `requirements.txt` file is
+provided.
+
+## Usage
+
+Run the model script:
+
+```bash
+python finance_model.py
+```
+
+The script prints the mean squared error on a hold-out set and shows the last five predictions
+compared to their actual values.
+
+## Notes
+
+This example is intentionally simple and uses a linear regression model with three lagged features.
+For real-world applications, more sophisticated models and data handling would be necessary.

--- a/finance_model.py
+++ b/finance_model.py
@@ -1,0 +1,73 @@
+import pandas as pd
+import numpy as np
+from sklearn.linear_model import LinearRegression
+import yfinance as yf
+
+
+def generate_synthetic_data(size=500, seed=0):
+    """Generate a synthetic price series using a simple random walk."""
+    rng = np.random.default_rng(seed)
+    steps = rng.normal(loc=0, scale=1, size=size)
+    prices = 100 + np.cumsum(steps)
+    dates = pd.date_range(end=pd.Timestamp.today(), periods=size)
+    return pd.DataFrame({"Close": prices}, index=dates)
+
+
+def load_data(ticker="AAPL", period="2y"):
+    """Download price data; fall back to synthetic data on failure."""
+    try:
+        data = yf.download(ticker, period=period, progress=False)
+        data = data[["Close"]]
+        data.dropna(inplace=True)
+        if len(data) == 0:
+            raise ValueError("No data returned")
+        return data
+    except Exception as exc:
+        print(f"Data download failed: {exc}. Using synthetic data instead.")
+        return generate_synthetic_data()
+
+
+def build_features(data, lags=3):
+    df = data.copy()
+    for i in range(1, lags + 1):
+        df[f"lag_{i}"] = df["Close"].shift(i)
+    df.dropna(inplace=True)
+    X = df[[f"lag_{i}" for i in range(1, lags + 1)]].values
+    y = df["Close"].values
+    return X, y
+
+
+def train_test_split_time_series(X, y, test_size=20):
+    if len(X) <= test_size:
+        raise ValueError("Not enough data for the test size")
+    X_train, X_test = X[:-test_size], X[-test_size:]
+    y_train, y_test = y[:-test_size], y[-test_size:]
+    return X_train, X_test, y_train, y_test
+
+
+def train_model(X_train, y_train):
+    model = LinearRegression()
+    model.fit(X_train, y_train)
+    return model
+
+
+def evaluate(model, X_test, y_test):
+    predictions = model.predict(X_test)
+    mse = np.mean((predictions - y_test) ** 2)
+    return mse, predictions
+
+
+def main():
+    data = load_data()
+    X, y = build_features(data)
+    X_train, X_test, y_train, y_test = train_test_split_time_series(X, y)
+    model = train_model(X_train, y_train)
+    mse, predictions = evaluate(model, X_test, y_test)
+    print("Mean Squared Error:", mse)
+    print("Last 5 Predictions vs Actuals:")
+    for pred, actual in zip(predictions[-5:], y_test[-5:]):
+        print(f"pred={pred:.2f}, actual={actual:.2f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+pandas
+scikit-learn
+yfinance


### PR DESCRIPTION
## Summary
- add simple linear-regression model in `finance_model.py`
- provide fallback to synthetic data when data download fails
- document usage in `README`
- add Python dependencies list

## Testing
- `python finance_model.py | head -n 5`


------
https://chatgpt.com/codex/tasks/task_e_684d91e010e48322a105f596fec18984